### PR TITLE
Fix opflex route: device should use var.infravlan

### DIFF
--- a/files/terraform_modules/nodes/main.tf
+++ b/files/terraform_modules/nodes/main.tf
@@ -16,7 +16,7 @@ data "ignition_file" "opflexroute" {
   path = "/etc/NetworkManager/dispatcher.d/80-opflex-route"
   mode = "493"
   content  {
-     content = "#!/bin/bash\n if [ \"$1\" == \"ens224.${var.infravlan}\" ] && [ \"$2\" == \"up\" ]; then \n route add -net 224.0.0.0 netmask 240.0.0.0 dev ens224.3901 \n fi\n"
+     content = "#!/bin/bash\n if [ \"$1\" == \"ens224.${var.infravlan}\" ] && [ \"$2\" == \"up\" ]; then \n route add -net 224.0.0.0 netmask 240.0.0.0 dev ens224.${var.infravlan} \n fi\n"
 
   }
 }


### PR DESCRIPTION
The opflexroute next hop device is hardcoded to ens224.3901. 
It should be ens224.${var.infravlan}