### PR TITLE
Update generation of masters_api_ip_list and workers_api_ip_list,

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -114,11 +114,11 @@
      machine_network_netmask: "{{ machine_network_cidr | ipaddr('netmask') }}"
 
 - set_fact:
-     masters_api_ip_list: "{{ masters_api_ip_list | default([])}} + ['{{ item.value.ip }}']"
+     masters_api_ip_list: "{{ masters_api_ip_list | default([]) + [ item.value.ip ] }}"
   with_dict: "{{ masters_vars.nodes }}"
 
 - set_fact:
-     workers_api_ip_list: "{{ workers_api_ip_list | default([])}} + ['{{ item.value.ip }}']"
+     workers_api_ip_list: "{{ workers_api_ip_list | default([]) + [ item.value.ip ] }}"
   with_dict: "{{ workers_vars.nodes }}"
 
 - set_fact:


### PR DESCRIPTION
because there is change in behaviour i.e.(We can no longer perform arithmetic and concatenation operations outside of the jinja template) for ansible version 2.13+.